### PR TITLE
Begins Profile components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /node_modules
 /dist
+npm-debug.log
 debug.log
 exceptions.log
 /config

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "mocha -w tests/client/fixtures/jsdom.js tests/client/* tests/server/*",
     "test:client": "mocha -w tests/client/fixtures/jsdom.js tests/client/*",
+    "test:profile": "mocha -w tests/client/fixtures/jsdom.js tests/client/ViewProfileTests/* tests/client/EditProfileTests/*",
     "test:server": "NODE_ENV=test mocha -w tests/server/*",
     "start": "node server/index.js",
     "start:dev": "NODE_ENV=test nodemon server/index.js",

--- a/src/client/components/App.jsx
+++ b/src/client/components/App.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import ViewProfile from 'ViewProfile';
 
 const App = () => {
   return (
     <div>
       Hello World!
+      <ViewProfile userData={userObject} />
     </div>
   );
 };

--- a/src/client/components/App.jsx
+++ b/src/client/components/App.jsx
@@ -1,11 +1,9 @@
 import React from 'react';
-import ViewProfile from 'ViewProfile';
 
 const App = () => {
   return (
     <div>
       Hello World!
-      <ViewProfile userData={userObject} />
     </div>
   );
 };

--- a/src/client/components/Loading.jsx
+++ b/src/client/components/Loading.jsx
@@ -1,0 +1,9 @@
+import React, { PropTypes } from 'react'
+
+const Loading = (props) => {
+  return (
+    <div>Loading...</div>
+  )
+}
+
+export default Loading

--- a/src/client/components/Profile.jsx
+++ b/src/client/components/Profile.jsx
@@ -1,0 +1,63 @@
+import React, { PropTypes } from 'react'
+import userObject from '../../tests/client/fixtures/userObject';
+import ViewProfile from './ViewProfile';
+import Loading from './Loading';
+
+/* Profile Controller Component
+ * Controller for the Container Component ProfileHolder
+ * Handles requesting a given user id from the server
+ * and rendering a profile view based on that data.
+ * If the user is viewing their own profile, this component
+ * will render EditProfile, which contains logic to update user records.
+ * Otherwise, it will render ViewProfile, which contains logic for the currently
+ * Logged-in user to follow/unfollow/DM the user being viewed.
+ */
+
+function fetchUser(id) {
+  // *MOCK* go get this user from the server and return it
+  return new Promise(function(resolve, reject) {
+    window.setTimeout(function() {
+      resolve({
+        firstName: userObject.first_name,
+        lastName: userObject.last_name,
+        email: userObject.email,
+        bio: userObject.bio,
+        imageUrl: userObject.image_url,
+        followers: userObject.followers,
+        following: userObject.following,
+      });
+    }, 1000);
+  });
+}
+
+function receiveViewUser(viewUser) {
+  // state change handler to dispatch update action
+  // once async fetchUser returns
+  return function update(state) {
+    return {
+      ...state,
+      viewUser,
+      loadingProfile: false,
+    };
+  };
+}
+
+class Profile extends React.Component {
+  componentWillMount() {
+    fetchUser(this.props.viewUserId)
+      .then(viewUser => this.setState(receiveViewUser(viewUser)));
+  }
+  render () {
+    // these conditionals check if our async data has returned yet,
+    // and if the user is viewing their own profile (which they can edit)
+    // or someone else's.
+    if (this.state.loadingProfile) return <Loading />
+    if (this.props.viewUserId === this.state.user._id) {
+      // this should actually return EditProfile once it exists
+      return (<ViewProfile userData={this.state.viewUser} />);
+    }
+    return (<ViewProfile userData={this.state.viewUser} />);
+  }
+}
+
+export default Profile;

--- a/src/client/components/ViewProfile.jsx
+++ b/src/client/components/ViewProfile.jsx
@@ -1,0 +1,19 @@
+import React, { PropTypes } from 'react'
+
+const ViewProfile = ({ viewUserData }) => {
+  const { email, firstName, lastName, bio, imageUrl, following, followers } = viewUserData;
+  return (
+    <div className="view-profile-container">
+      <h2>{firstName} {lastName}</h2>
+      <h4 className="view-profile-email">{email}</h4>
+      <img alt={`${firstName}'s profile pic`} className="view-profile-pic" src={imageUrl} />
+      <p className="view-profile-bio">
+        {bio}
+      </p>
+      <h4>Following: </h4> {following.map(followee => <span className="view-profile-followee">{ followee }</span>)}
+      <h4>Followers: </h4> {followers.map(follower => <span className="view-profile-follower">{ follower }</span>)}
+    </div>
+  );
+};
+
+export default ViewProfile;

--- a/src/client/containers/ProfileHolder.jsx
+++ b/src/client/containers/ProfileHolder.jsx
@@ -1,0 +1,18 @@
+import { connect } from 'react-redux'
+import Profile from '../components/Profile'
+
+const mapStateToProps = (state) => ({
+  user: state.user,
+  viewUser: state.viewUser,
+});
+
+// changeViewUser,
+const mapDispatchToProps = ({
+});
+
+const ProfileHolder = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(Profile);
+
+export default ProfileHolder

--- a/tests/client/LoginTests/LoginActionCreators.spec.js
+++ b/tests/client/LoginTests/LoginActionCreators.spec.js
@@ -8,15 +8,15 @@ import {
   loginActionSuccessFixture,
   loginActionFailureFixture1,
   loginActionFailureFixture2,
-} from './../fixtures/LoginFixtures/loginActionFixtures';
+} from './../fixtures/ActionFixtures/loginActionFixtures';
 import {
   forgotPasswordMockActionPayload1,
   forgotPasswordMockActionPayload2,
   forgotPasswordSuccessFixture,
   forgotPasswordFailureFixture,
-} from './../fixtures/LoginFixtures/forgotPasswordActionFixtures';
-// import * as actions from '../../../../src/client/actions/index';
-// import * as types from '../../../../src/client/actions/ActionTypes';
+} from './../fixtures/ActionFixtures/forgotPasswordActionFixtures';
+import * as actions from '../../../../src/client/actions/index';
+import * as types from '../../../../src/client/actions/ActionTypes';
 
 describe('Action Creator: loginUser', () => {
   after(() => {

--- a/tests/client/ViewProfileTests/ViewProfile.spec.jsx
+++ b/tests/client/ViewProfileTests/ViewProfile.spec.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { shallow, mount }
+from 'enzyme';
+import { expect }
+from 'chai';
+import ViewProfile from '../../../src/client/components/ViewProfile';
+import userObject from '../fixtures/userObject';
+
+const viewUser = {
+  firstName: userObject.first_name,
+  lastName: userObject.last_name,
+  email: userObject.email,
+  bio: userObject.bio,
+  imageUrl: userObject.image_url,
+  followers: userObject.followers,
+  following: userObject.following,
+};
+
+describe('Component: <ViewProfile />', () => {
+  const wrapper = shallow(<ViewProfile viewUserData={viewUser} />);
+
+  it('should render name', () => {
+    expect(wrapper.find('h2').text().includes('Tony')).to.equal(true);
+  });
+
+  it('should render profile pic', () => {
+    expect(wrapper.find('img')).to.have.length(1);
+  });
+
+  it('should render bio', () => {
+    expect(wrapper.find('.view-profile-bio').text().includes('sugar')).to.equal(true);
+  });
+
+  it('should render followers', () => {
+    expect(wrapper.find('.view-profile-follower')).to.have.length(2);
+  });
+
+  it('should render followees', () => {
+    expect(wrapper.find('.view-profile-followee')).to.have.length(2);
+  });
+});

--- a/tests/client/fixtures/mockStore.js
+++ b/tests/client/fixtures/mockStore.js
@@ -5,11 +5,15 @@ const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
 mockStore({
   user: {
+    _id: 1,
     name: '',
     email: '',
     username: '',
     isPending: false,
     isLoggedIn: false,
+  },
+  viewUser: {
+
   },
 });
 

--- a/tests/client/fixtures/userObject.js
+++ b/tests/client/fixtures/userObject.js
@@ -1,0 +1,14 @@
+const { encryptPassword } = require('../../../server/utils/validate');
+
+module.exports = {
+  _id: 1,
+  email: 'test@xyz.io',
+  password: encryptPassword('Shoes2231'),
+  first_name: 'Tony',
+  last_name: 'Tiger',
+  dob: '2017-10-1',
+  bio: 'Ate a lot of sugar. Grew up to be GRRRREEEAAAAAT!',
+  image_url: 'http://placekitten.com/g/250/250',
+  following: [2, 3],
+  followers: [2, 3],
+};


### PR DESCRIPTION
This relatively small pull already raises some issues; I tried to break them down a bit to who they concern:

## Front End Team
- Anyone have strong feelings on how we should handle styling? Right now I'm only adding classNames, namespaced by the component that renders them (i.e. 'view-profile-follower' is the classname of a follower span in the 'ViewProfile' component)...that way we can keep our styles somewhat modular with vanilla SASS; I'm definitely down to try one of the solutions for compartmentalizing styles in the actual react component that needs them, but I don't have an opinion on which we should use.

## Back End Team
- We probably need to talk as a whole team about routing principles, but it seems like GET users/:user_id from the browser should probably jump into our app at the view profile state, rather than return a json? Maybe we should put all our api calls in a sub-route (ie `rallypointhost/api/users/:user_id`)?
- The 'user object' in `tests/server/fixtures/userFixtures` is out of sync with the object in `tests/client/fixtures/userObject`...this is because I added some properties that I was relatively sure we would want in the user Objects, and figured that'd be a good way to communicate the front end's needs (i.e. by us writing what we think user objects sent by the server 'should' look like) to the back end team.
- Property names for the mentioned user Objects as returned from the server are not camelCase.  I realize in the db they will be snake_case, but once we get them into JS they should be camelCase, no?  The question is - do we do this property renaming serverside or clientside?  Unless anyone sees why we shouldn't, I'll start writing the client to switch snake_case to camelCase as the server's response is being integrated into the user Object help in the app's state.